### PR TITLE
fixing issue #1

### DIFF
--- a/delphi/Inputs.js
+++ b/delphi/Inputs.js
@@ -1,6 +1,11 @@
 import TControl from './TControl.js'
 
 export default `
+[contenteditable] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 .TApplication .TForm .TEdit {
   box-sizing: border-box;
   background-color: var(--input-background-color);


### PR DESCRIPTION
Safari has the user-select CSS setting as none by default. 
See [StackOverflow](https://stackoverflow.com/questions/20435166/contenteditable-not-working-in-safari-but-works-in-chrome)